### PR TITLE
Add timeout parameters to mysql driver

### DIFF
--- a/fddb/config.go
+++ b/fddb/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 type DBConfig struct {
@@ -27,6 +28,7 @@ type DBConfig struct {
 	User     string
 	Password string
 	DB       string
+	Timeout time.Duration
 }
 
 var availableDrivers = map[string]DBConfig{
@@ -88,6 +90,12 @@ func (c DBConfig) init() DBConfig {
 		}
 	}
 
+	if c.Timeout.String() == "0s" {
+		if defaultCfg.Timeout.String() != "0s" {
+			c.Timeout = defaultCfg.Timeout
+		}
+	}
+
 	return c
 }
 
@@ -101,6 +109,11 @@ func (c DBConfig) ConnString() string {
 		usrPwd += ":" + c.Password
 	}
 
+	timeOut := ""
+	if c.Timeout.String != "0s" {
+		timeOut = "?" + c.Timeout.String()
+	}
+
 	var host string
 	if c.Host != "" {
 		host = fmt.Sprintf("%s:%s", c.Host, c.Port)
@@ -108,7 +121,7 @@ func (c DBConfig) ConnString() string {
 
 	switch c.Driver {
 	case "mysql":
-		return fmt.Sprintf("%s@tcp(%s)/%s", usrPwd, host, c.DB)
+		return fmt.Sprintf("%s@tcp(%s)/%s%s", usrPwd, host, c.DB, timeOut)
 	case "redis":
 		return host
 	case "mongodb":

--- a/fddb/config.go
+++ b/fddb/config.go
@@ -92,15 +92,15 @@ func (c DBConfig) init() DBConfig {
 		}
 	}
 
-	if c.Timeout == 0 && defaultCfg.Timeout != 0 {
+	if c.Timeout == 0 {
 		c.Timeout = defaultCfg.Timeout
 	}
 
-	if c.ReadTimeout == 0 && defaultCfg.ReadTimeout != 0 {
+	if c.ReadTimeout == 0 {
 		c.ReadTimeout = defaultCfg.ReadTimeout
 	}
 
-	if c.WriteTimeout == 0 && defaultCfg.WriteTimeout != 0 {
+	if c.WriteTimeout == 0 {
 		c.WriteTimeout = defaultCfg.WriteTimeout
 	}
 

--- a/fddb/config.go
+++ b/fddb/config.go
@@ -25,12 +25,12 @@ type DBConfig struct {
 	// to all (host:port and each address informed in Addrs)
 	Addrs []string
 
-	User     string
-	Password string
-	DB       string
-	Timeout  time.Duration
+	User         string
+	Password     string
+	DB           string
+	Timeout      time.Duration
 	ReadTimeout  time.Duration
-	WriteTimeout  time.Duration
+	WriteTimeout time.Duration
 }
 
 var availableDrivers = map[string]DBConfig{
@@ -119,15 +119,15 @@ func (c DBConfig) ConnString() string {
 
 	var dsnParams []string
 	if c.Timeout != 0 {
-		dsnParams = append(dsnParams, "timeout=" + c.Timeout.String())
+		dsnParams = append(dsnParams, "timeout="+c.Timeout.String())
 	}
 
 	if c.ReadTimeout != 0 {
-		dsnParams = append(dsnParams, "readTimeout=" + c.ReadTimeout.String())
+		dsnParams = append(dsnParams, "readTimeout="+c.ReadTimeout.String())
 	}
 
 	if c.WriteTimeout != 0 {
-		dsnParams = append(dsnParams, "writeTimeout=" + c.WriteTimeout.String())
+		dsnParams = append(dsnParams, "writeTimeout="+c.WriteTimeout.String())
 	}
 
 	var host string

--- a/fddb/config.go
+++ b/fddb/config.go
@@ -28,7 +28,7 @@ type DBConfig struct {
 	User     string
 	Password string
 	DB       string
-	Timeout time.Duration
+	Timeout  time.Duration
 }
 
 var availableDrivers = map[string]DBConfig{

--- a/fddb/config.go
+++ b/fddb/config.go
@@ -110,7 +110,7 @@ func (c DBConfig) ConnString() string {
 	}
 
 	timeOut := ""
-	if c.Timeout.String != "0s" {
+	if c.Timeout.String() != "0s" {
 		timeOut = "?" + c.Timeout.String()
 	}
 

--- a/fddb/config.go
+++ b/fddb/config.go
@@ -92,22 +92,16 @@ func (c DBConfig) init() DBConfig {
 		}
 	}
 
-	if c.Timeout == 0 {
-		if defaultCfg.Timeout != 0 {
-			c.Timeout = defaultCfg.Timeout
-		}
+	if c.Timeout == 0 && defaultCfg.Timeout != 0 {
+		c.Timeout = defaultCfg.Timeout
 	}
 
-	if c.ReadTimeout == 0 {
-		if defaultCfg.ReadTimeout != 0 {
-			c.ReadTimeout = defaultCfg.ReadTimeout
-		}
+	if c.ReadTimeout == 0 && defaultCfg.ReadTimeout != 0 {
+		c.ReadTimeout = defaultCfg.ReadTimeout
 	}
 
-	if c.WriteTimeout == 0 {
-		if defaultCfg.WriteTimeout != 0 {
-			c.WriteTimeout = defaultCfg.WriteTimeout
-		}
+	if c.WriteTimeout == 0 && defaultCfg.WriteTimeout != 0 {
+		c.WriteTimeout = defaultCfg.WriteTimeout
 	}
 
 	return c
@@ -123,29 +117,17 @@ func (c DBConfig) ConnString() string {
 		usrPwd += ":" + c.Password
 	}
 
-	dsnParams := ""
+	var dsnParams []string
 	if c.Timeout != 0 {
-		if dsnParams != "" {
-			dsnParams += "&timeout=" + c.Timeout.String()
-		} else {
-			dsnParams = "timeout=" + c.Timeout.String()
-		}
+		dsnParams = append(dsnParams, "timeout=" + c.Timeout.String())
 	}
 
 	if c.ReadTimeout != 0 {
-		if dsnParams != "" {
-			dsnParams += "&readTimeout=" + c.ReadTimeout.String()
-		} else {
-			dsnParams = "readTimeout=" + c.ReadTimeout.String()
-		}
+		dsnParams = append(dsnParams, "readTimeout=" + c.ReadTimeout.String())
 	}
 
 	if c.WriteTimeout != 0 {
-		if dsnParams != "" {
-			dsnParams += "&writeTimeout=" + c.WriteTimeout.String()
-		} else {
-			dsnParams = "writeTimeout=" + c.WriteTimeout.String()
-		}
+		dsnParams = append(dsnParams, "writeTimeout=" + c.WriteTimeout.String())
 	}
 
 	var host string
@@ -155,8 +137,8 @@ func (c DBConfig) ConnString() string {
 
 	switch c.Driver {
 	case "mysql":
-		if dsnParams != "" {
-			return fmt.Sprintf("%s@tcp(%s)/%s?%s", usrPwd, host, c.DB, dsnParams)
+		if len(dsnParams) > 0 {
+			return fmt.Sprintf("%s@tcp(%s)/%s?%s", usrPwd, host, c.DB, strings.Join(dsnParams, "&"))
 		}
 		return fmt.Sprintf("%s@tcp(%s)/%s", usrPwd, host, c.DB)
 	case "redis":

--- a/fddb/config_test.go
+++ b/fddb/config_test.go
@@ -147,14 +147,16 @@ func TestDBConfigConnString_MySQL(t *testing.T) {
 
 func TestDBConfigConnFullString_MySQL(t *testing.T) {
 	c := DBConfig{
-		Driver:       "mysql",
-		Host:         "127.0.0.1",
-		Port:         "3306",
-		User:         "root",
-		DB:           "test",
-		Timeout:      10000000,
-		ReadTimeout:  20000000,
-		WriteTimeout: 30000000,
+		Driver: "mysql",
+		Host:   "127.0.0.1",
+		Port:   "3306",
+		User:   "root",
+		DB:     "test",
+		MysqlOptions: MysqlOptions{
+			Timeout:      10000000,
+			ReadTimeout:  20000000,
+			WriteTimeout: 30000000,
+		},
 	}
 	assert.Equal(t, c.ConnString(), "root@tcp(127.0.0.1:3306)/test?timeout=10ms&readTimeout=20ms&writeTimeout=30ms")
 

--- a/fddb/config_test.go
+++ b/fddb/config_test.go
@@ -133,6 +133,20 @@ func TestDBConfigString(t *testing.T) {
 
 func TestDBConfigConnString_MySQL(t *testing.T) {
 	c := DBConfig{
+		Driver: "mysql",
+		Host:   "127.0.0.1",
+		Port:   "3306",
+		User:   "root",
+		DB:     "test",
+	}
+	assert.Equal(t, c.ConnString(), "root@tcp(127.0.0.1:3306)/test")
+
+	c.Password = "r007"
+	assert.Equal(t, c.ConnString(), "root:r007@tcp(127.0.0.1:3306)/test")
+}
+
+func TestDBConfigConnFullString_MySQL(t *testing.T) {
+	c := DBConfig{
 		Driver:       "mysql",
 		Host:         "127.0.0.1",
 		Port:         "3306",

--- a/fddb/config_test.go
+++ b/fddb/config_test.go
@@ -133,13 +133,13 @@ func TestDBConfigString(t *testing.T) {
 
 func TestDBConfigConnString_MySQL(t *testing.T) {
 	c := DBConfig{
-		Driver: "mysql",
-		Host:   "127.0.0.1",
-		Port:   "3306",
-		User:   "root",
-		DB:     "test",
-		Timeout: 10000000,
-		ReadTimeout: 20000000,
+		Driver:       "mysql",
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		User:         "root",
+		DB:           "test",
+		Timeout:      10000000,
+		ReadTimeout:  20000000,
 		WriteTimeout: 30000000,
 	}
 	assert.Equal(t, c.ConnString(), "root@tcp(127.0.0.1:3306)/test?timeout=10ms&readTimeout=20ms&writeTimeout=30ms")

--- a/fddb/config_test.go
+++ b/fddb/config_test.go
@@ -1,9 +1,8 @@
 package fddb
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestDBConfig(t *testing.T) {
@@ -139,11 +138,14 @@ func TestDBConfigConnString_MySQL(t *testing.T) {
 		Port:   "3306",
 		User:   "root",
 		DB:     "test",
+		Timeout: 10000000,
+		ReadTimeout: 20000000,
+		WriteTimeout: 30000000,
 	}
-	assert.Equal(t, c.ConnString(), "root@tcp(127.0.0.1:3306)/test")
+	assert.Equal(t, c.ConnString(), "root@tcp(127.0.0.1:3306)/test?timeout=10ms&readTimeout=20ms&writeTimeout=30ms")
 
 	c.Password = "r007"
-	assert.Equal(t, c.ConnString(), "root:r007@tcp(127.0.0.1:3306)/test")
+	assert.Equal(t, c.ConnString(), "root:r007@tcp(127.0.0.1:3306)/test?timeout=10ms&readTimeout=20ms&writeTimeout=30ms")
 }
 
 func TestDBConfigConnString_Postgres(t *testing.T) {


### PR DESCRIPTION
The [Go-MySQL-Driver](https://github.com/go-sql-driver/mysql#connection-pool-and-timeouts) package supports `timeout` parameters but the current implementation in go-ranger does not support DSN parameters.

The DSN MySql string supports three timeout parameters `readTimeout`, `writeTimeout` and `timeout`.

This PR introduces the usage of DSN parameters as part of the connection string by exposing the timeout parameters in the `DBConfig` struct.