### PR TITLE
NO_TICKET. A way to pass extra params for health check output

### DIFF
--- a/fdhttp/fdhandler/health_check.go
+++ b/fdhttp/fdhandler/health_check.go
@@ -36,6 +36,7 @@ type HealthCheckResponse struct {
 		TotalAllocBytes uint64 `json:"total_alloc_bytes"`
 		AllocBytes      uint64 `json:"alloc_bytes"`
 	} `json:"system,omitempty"`
+	Extra map[string]string `json:"extra,omitempty"`
 	sync.Mutex
 }
 
@@ -73,6 +74,8 @@ type HealthCheck struct {
 	commit   string
 	hostname string
 	services map[string]HealthChecker
+
+	extraParams map[string]string
 }
 
 // NewHealthCheck create a new healthcheck handler
@@ -86,6 +89,12 @@ func NewHealthCheck(tag, commit string) *HealthCheck {
 		services:       make(map[string]HealthChecker),
 		ServiceTimeout: HealthCheckServiceTimeout,
 	}
+}
+
+// WithExtraParams is for setting extra static params in a form of map of strings
+func (h *HealthCheck) WithExtraParams(extraParams map[string]string) *HealthCheck {
+	h.extraParams = extraParams
+	return h
 }
 
 // Init will be called by fdhttp.Router to register fdhandler.HealthCheckURL
@@ -128,6 +137,10 @@ func (h *HealthCheck) newResponse() *HealthCheckResponse {
 	resp.System.AllocBytes = mem.HeapAlloc
 	resp.System.TotalAllocBytes = mem.TotalAlloc
 	resp.System.NumHeapObjects = mem.HeapObjects
+
+	if len(h.extraParams) > 0 {
+		resp.Extra = h.extraParams
+	}
 
 	return resp
 }

--- a/fdhttp/fdhandler/health_check.go
+++ b/fdhttp/fdhandler/health_check.go
@@ -70,11 +70,10 @@ type HealthCheck struct {
 	// before we get a timeout.
 	ServiceTimeout time.Duration
 
-	tag      string
-	commit   string
-	hostname string
-	services map[string]HealthChecker
-
+	tag         string
+	commit      string
+	hostname    string
+	services    map[string]HealthChecker
 	extraParams map[string]string
 }
 


### PR DESCRIPTION
With this feature, you can pass static extra params to be shown on health-check page.
You can do it like this:
```
extra := map[string]string{
	"param1": "val1",
	"param2": "val2",
}

_ = fdhandler.NewHealthCheck(gitTag, gitHash).
    WithExtraParams(extra)
```
