### PR TITLE
fix newrelic transaction grouping

### DIFF
--- a/fdapm/newrelic_middleware.go
+++ b/fdapm/newrelic_middleware.go
@@ -13,7 +13,11 @@ import (
 func NewRelicMiddleware(app newrelic.Application) fdmiddleware.Middleware {
 	return fdmiddleware.MiddlewareFunc(func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, req *http.Request) {
-			txn := newrelic.FromContext(req.Context())
+			var txn newrelic.Transaction
+			txn = newrelic.FromContext(req.Context())
+			if txn == nil {
+				txn = app.StartTransaction(req.URL.Path, w, req)
+			}
 			defer txn.End()
 
 			ctx := SetNewRelicTransaction(req.Context(), txn)

--- a/fdapm/newrelic_middleware.go
+++ b/fdapm/newrelic_middleware.go
@@ -13,7 +13,7 @@ import (
 func NewRelicMiddleware(app newrelic.Application) fdmiddleware.Middleware {
 	return fdmiddleware.MiddlewareFunc(func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, req *http.Request) {
-			txn := app.StartTransaction(req.URL.Path, w, req)
+			txn := newrelic.FromContext(req.Context())
 			defer txn.End()
 
 			ctx := SetNewRelicTransaction(req.Context(), txn)


### PR DESCRIPTION
Grouping by Path create issues on NewRelic, which may lead to getting blocked by them, making new metrics not appear