### PR TITLE
awssub remove incorrect debug log

### DIFF
--- a/pubsub/awssub/sub.go
+++ b/pubsub/awssub/sub.go
@@ -278,7 +278,6 @@ func (s *subscriber) Start() <-chan pubsub.Message {
 				continue
 			}
 
-			s.Logger.Printf("found %d messages", len(resp.Messages))
 			// for each message, pass to output
 			for _, msg := range resp.Messages {
 				select {


### PR DESCRIPTION
There is no way now to write a log specifically with debug level.
Most loggers use Printf to wrap Info log, as a result we write debug logs as info.