### PR TITLE
Add HTTP Method to Newrelic Transaction Name

### DIFF
--- a/fdapm/newrelic_middleware.go
+++ b/fdapm/newrelic_middleware.go
@@ -3,6 +3,7 @@ package fdapm
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/foodora/go-ranger/fdhttp/fdmiddleware"
@@ -16,7 +17,7 @@ func NewRelicMiddleware(app newrelic.Application) fdmiddleware.Middleware {
 			var txn newrelic.Transaction
 			txn = newrelic.FromContext(req.Context())
 			if txn == nil {
-				txn = app.StartTransaction(req.URL.Path, w, req)
+				txn = app.StartTransaction(fmt.Sprintf("%s %s", req.Method, req.URL.Path), w, req)
 			}
 			defer txn.End()
 


### PR DESCRIPTION
This adds the http method (`GET`, `POST`, etc.) to new relic transaction name.

### Why?
To differentiate newrelic transactions from the same endpoint path with different http method.


### **Before:**
![image](https://user-images.githubusercontent.com/44870598/69975690-efd76500-1527-11ea-8348-854585cf270f.png)

### **After:**
![image](https://user-images.githubusercontent.com/44870598/69976423-42fde780-1529-11ea-8496-02f5d979f795.png)

