### PR TITLE
inherit middlewares of parent routers

### DIFF
--- a/fdhttp/router.go
+++ b/fdhttp/router.go
@@ -270,9 +270,11 @@ func (r *Router) Handler(method, path string, fn EndpointFunc) *Endpoint {
 			}
 		})
 
-		if r.parent != nil {
-			// if is a sub router let's wrap middlewares
-			handler = r.wrapMiddlewares(handler)
+		currentRouter := r
+		for currentRouter.parent != nil {
+			// wrap with all middlewares of parents
+			handler = currentRouter.wrapMiddlewares(handler)
+			currentRouter = currentRouter.parent
 		}
 
 		handler.ServeHTTP(w, req)

--- a/fdhttp/router_test.go
+++ b/fdhttp/router_test.go
@@ -306,15 +306,6 @@ func TestSubRouter_MiddlewareOfParentSubrouterIsCalled(t *testing.T) {
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
-	//resp, err := http.Get(ts.URL + "/")
-	//assert.NoError(t, err)
-	//
-	//body, _ := ioutil.ReadAll(resp.Body)
-	//assert.Equal(t, "handler", string(body))
-	//resp.Body.Close()
-	//assert.False(t, mCalled)
-	//mCalled = false
-
 	resp, err := http.Get(ts.URL + "/prefix1")
 	assert.NoError(t, err)
 


### PR DESCRIPTION
StdHandlers inherit Parent router's middlewares.
fdhttp.Handler interfaces don't.

So with this solution I recursively go parent by parent and wrap my handler with their middlewares.

**Backwards compatibility** - if someone redeclare a list of middlewares in each subrouter they would start run them many times.



p.s. I've added tests as well.

