### PR TITLE
Use supplied AWS Config instead of creating new ones

### DIFF
--- a/pubsub/awspub/pub.go
+++ b/pubsub/awspub/pub.go
@@ -34,10 +34,8 @@ func NewPublisher(cfg SNSConfig) (pubsub.Publisher, error) {
 		return p, err
 	}
 
-	p.sns = sns.New(sess, &aws.Config{
-		Region:   cfg.Region,
-		Endpoint: cfg.Endpoint, //optional
-	})
+	p.sns = sns.New(sess, &cfg.Config)
+
 	return p, nil
 }
 

--- a/pubsub/awssub/sub.go
+++ b/pubsub/awssub/sub.go
@@ -154,10 +154,7 @@ func createSqsClient(cfg *SQSConfig) (sqsiface.SQSAPI, error) {
 		return nil, err
 	}
 
-	sqsClient := sqs.New(sess, &aws.Config{
-		Region:   cfg.Region,
-		Endpoint: cfg.Endpoint,
-	})
+	sqsClient := sqs.New(sess, &cfg.Config)
 
 	return sqsClient, nil
 }


### PR DESCRIPTION
While trying to change the way that application configs were being loaded, we found an issue where the configuration was just ignored.
Apparently go-ranger was just taking a few configs from the object and discarding everything else.