### PR TITLE
Update newrelic transaction mock

### DIFF
--- a/fdapm/apmmock/newrelic_transaction.go
+++ b/fdapm/apmmock/newrelic_transaction.go
@@ -9,6 +9,8 @@ import (
 	newrelic "github.com/newrelic/go-agent"
 )
 
+var _ newrelic.Transaction = (*NewRelicTransaction)(nil)
+
 type NewRelicTransaction struct {
 	mu sync.Mutex
 
@@ -121,4 +123,19 @@ func (t *NewRelicTransaction) SetWebRequest(req newrelic.WebRequest) error {
 // SetWebResponse ...
 func (t *NewRelicTransaction) SetWebResponse(w http.ResponseWriter) newrelic.Transaction {
 	return nil
+}
+
+// GetTraceMetadata ..
+func (t *NewRelicTransaction) GetTraceMetadata() newrelic.TraceMetadata {
+	return newrelic.TraceMetadata{}
+}
+
+// GetLinkingMetadata ..
+func (t *NewRelicTransaction) GetLinkingMetadata() newrelic.LinkingMetadata {
+	return newrelic.LinkingMetadata{}
+}
+
+// IsSampled ..
+func (t *NewRelicTransaction) IsSampled() bool {
+	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/johntdyer/slackrus v0.0.0-20180518184837-f7aae3243a07
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da
-	github.com/newrelic/go-agent v2.7.0+incompatible
+	github.com/newrelic/go-agent v3.3.0+incompatible
 	github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea // indirect
 	github.com/rubyist/circuitbreaker v2.2.1+incompatible
 	github.com/sirupsen/logrus v1.2.0
@@ -24,6 +24,6 @@ require (
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816 // indirect
 	golang.org/x/sys v0.0.0-20181031143558-9b800f95dbbc // indirect
 	golang.org/x/text v0.3.0 // indirect
-	gopkg.in/throttled/throttled.v2 v2.0.3
+	gopkg.in/throttled/throttled.v2 v2.0.3 // indirect
 	gopkg.in/yaml.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/newrelic/go-agent v2.1.0+incompatible h1:fCuxXeM4eeIKPbzffOWW6y2Dj+eY
 github.com/newrelic/go-agent v2.1.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 github.com/newrelic/go-agent v2.7.0+incompatible h1:T5tJ9nNY1bXBfLUTCEZRuBLPT0f9+mE1jd4EaNoN5Zs=
 github.com/newrelic/go-agent v2.7.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
+github.com/newrelic/go-agent v3.3.0+incompatible h1:2J3ssCWfOl/j/c+dV0Ps8BZaNStWPw8ApHA2AqVjEi8=
+github.com/newrelic/go-agent v3.3.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea h1:sKwxy1H95npauwu8vtF95vG/syrL0p8fSZo/XlDg5gk=
 github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea/go.mod h1:1VcHEd3ro4QMoHfiNl/j7Jkln9+KQuorp0PItHMJYNg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
- updated newrelic go-agent version: v2.7.0 -> v3.3.0
- updated the implementation of newrelic Transaction mock with new methods