### PR TITLE
POP-564 remove system version health check endpoint

### DIFF
--- a/fdhttp/fdhandler/health_check.go
+++ b/fdhttp/fdhandler/health_check.go
@@ -29,12 +29,12 @@ type HealthCheckResponse struct {
 	Hostname string                                 `json:"hostname"`
 	Checks   map[string]*HealthCheckServiceResponse `json:"checks,omitempty"`
 	System   struct {
-		Version         string `json:"version"`
-		NumCPU          int    `json:"num_cpu"`
-		NumGoroutines   int    `json:"num_goroutines"`
-		NumHeapObjects  uint64 `json:"num_heap_objects"`
-		TotalAllocBytes uint64 `json:"total_alloc_bytes"`
-		AllocBytes      uint64 `json:"alloc_bytes"`
+		Version         *string `json:"version,omitempty"`
+		NumCPU          int     `json:"num_cpu"`
+		NumGoroutines   int     `json:"num_goroutines"`
+		NumHeapObjects  uint64  `json:"num_heap_objects"`
+		TotalAllocBytes uint64  `json:"total_alloc_bytes"`
+		AllocBytes      uint64  `json:"alloc_bytes"`
 	} `json:"system,omitempty"`
 	Extra map[string]string `json:"extra,omitempty"`
 	sync.Mutex
@@ -70,12 +70,13 @@ type HealthCheck struct {
 	// before we get a timeout.
 	ServiceTimeout time.Duration
 
-	tag           string
-	commit        string
-	hostname      string
-	servicesGuard sync.RWMutex
-	services      map[string]HealthChecker
-	extraParams   map[string]string
+	tag                  string
+	commit               string
+	hostname             string
+	servicesGuard        sync.RWMutex
+	services             map[string]HealthChecker
+	extraParams          map[string]string
+	disableSystemVersion bool
 }
 
 // NewHealthCheck create a new healthcheck handler
@@ -83,17 +84,23 @@ func NewHealthCheck(tag, commit string) *HealthCheck {
 	hostname, _ := os.Hostname()
 
 	return &HealthCheck{
-		tag:            tag,
-		commit:         commit,
-		hostname:       hostname,
-		services:       make(map[string]HealthChecker),
-		ServiceTimeout: HealthCheckServiceTimeout,
+		tag:                  tag,
+		commit:               commit,
+		hostname:             hostname,
+		services:             make(map[string]HealthChecker),
+		ServiceTimeout:       HealthCheckServiceTimeout,
+		disableSystemVersion: false,
 	}
 }
 
 // WithExtraParams is for setting extra static params in a form of map of strings
 func (h *HealthCheck) WithExtraParams(extraParams map[string]string) *HealthCheck {
 	h.extraParams = extraParams
+	return h
+}
+
+func (h *HealthCheck) DisableSystemVersion() *HealthCheck {
+	h.disableSystemVersion = true
 	return h
 }
 
@@ -130,7 +137,11 @@ func (h *HealthCheck) newResponse() *HealthCheckResponse {
 	resp.Version.Tag = h.tag
 	resp.Version.Commit = h.commit
 
-	resp.System.Version = runtime.Version()
+	if !h.disableSystemVersion {
+		verOut := runtime.Version()
+		resp.System.Version = &verOut
+	}
+
 	resp.System.NumCPU = runtime.NumCPU()
 	resp.System.NumGoroutines = runtime.NumGoroutine()
 

--- a/fdhttp/fdhandler/health_check.go
+++ b/fdhttp/fdhandler/health_check.go
@@ -29,12 +29,12 @@ type HealthCheckResponse struct {
 	Hostname string                                 `json:"hostname"`
 	Checks   map[string]*HealthCheckServiceResponse `json:"checks,omitempty"`
 	System   struct {
-		Version         *string `json:"version,omitempty"`
-		NumCPU          int     `json:"num_cpu"`
-		NumGoroutines   int     `json:"num_goroutines"`
-		NumHeapObjects  uint64  `json:"num_heap_objects"`
-		TotalAllocBytes uint64  `json:"total_alloc_bytes"`
-		AllocBytes      uint64  `json:"alloc_bytes"`
+		Version         string `json:"version,omitempty"`
+		NumCPU          int    `json:"num_cpu"`
+		NumGoroutines   int    `json:"num_goroutines"`
+		NumHeapObjects  uint64 `json:"num_heap_objects"`
+		TotalAllocBytes uint64 `json:"total_alloc_bytes"`
+		AllocBytes      uint64 `json:"alloc_bytes"`
 	} `json:"system,omitempty"`
 	Extra map[string]string `json:"extra,omitempty"`
 	sync.Mutex
@@ -138,8 +138,7 @@ func (h *HealthCheck) newResponse() *HealthCheckResponse {
 	resp.Version.Commit = h.commit
 
 	if !h.disableSystemVersion {
-		verOut := runtime.Version()
-		resp.System.Version = &verOut
+		resp.System.Version = runtime.Version()
 	}
 
 	resp.System.NumCPU = runtime.NumCPU()

--- a/fdhttp/fdhandler/health_check_test.go
+++ b/fdhttp/fdhandler/health_check_test.go
@@ -49,9 +49,28 @@ func TestHealthCheck(t *testing.T) {
 	assert.Equal(t, "1.0.0", healthResp.Version.Tag)
 	assert.Equal(t, "c6053cf", healthResp.Version.Commit)
 	assert.Equal(t, hostname, healthResp.Hostname)
-	assert.Equal(t, runtime.Version(), healthResp.System.Version)
+	assert.Equal(t, runtime.Version(), *healthResp.System.Version)
 	assert.Equal(t, runtime.NumCPU(), healthResp.System.NumCPU)
 	assert.Equal(t, time.Duration(0), healthResp.Elapsed)
+}
+
+func TestHealthCheckNoSystemVersion(t *testing.T) {
+	h := fdhandler.NewHealthCheck("1.0.0", "c6053cf").DisableSystemVersion()
+
+	router := fdhttp.NewRouter()
+	router.Register(h)
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/health/check")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var healthResp fdhandler.HealthCheckResponse
+	defer resp.Body.Close()
+
+	assert.Empty(t, healthResp.System.Version)
 }
 
 func TestHealthCheck_WithPrefixAndDifferentURL(t *testing.T) {

--- a/fdhttp/fdhandler/health_check_test.go
+++ b/fdhttp/fdhandler/health_check_test.go
@@ -49,7 +49,7 @@ func TestHealthCheck(t *testing.T) {
 	assert.Equal(t, "1.0.0", healthResp.Version.Tag)
 	assert.Equal(t, "c6053cf", healthResp.Version.Commit)
 	assert.Equal(t, hostname, healthResp.Hostname)
-	assert.Equal(t, runtime.Version(), *healthResp.System.Version)
+	assert.Equal(t, runtime.Version(), healthResp.System.Version)
 	assert.Equal(t, runtime.NumCPU(), healthResp.System.NumCPU)
 	assert.Equal(t, time.Duration(0), healthResp.Elapsed)
 }


### PR DESCRIPTION
This change is to mitigate a security concern that exposing system version could increase attack vector for the applications