### PR TITLE
Mysql add reject read only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# **DEPRECATED** - no longer actively maintained
+---
 <p align="center">
  <img alt="ranger" src="ranger.png" >
 </p>

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ See more on ```example.go```
 
 # Libraries used
 
-See ```Gopkg.toml```
+See ```go.mod```

--- a/fddb/config.go
+++ b/fddb/config.go
@@ -32,9 +32,10 @@ type DBConfig struct {
 }
 
 type MysqlOptions struct {
-	Timeout      time.Duration
-	ReadTimeout  time.Duration
-	WriteTimeout time.Duration
+	Timeout        time.Duration
+	ReadTimeout    time.Duration
+	WriteTimeout   time.Duration
+	RejectReadOnly bool
 }
 
 var availableDrivers = map[string]DBConfig{
@@ -146,6 +147,10 @@ func (c DBConfig) mySqlConnString(host, usrPwd string) string {
 
 	if c.MysqlOptions.WriteTimeout != 0 {
 		dsnParams = append(dsnParams, "writeTimeout="+c.MysqlOptions.WriteTimeout.String())
+	}
+
+	if c.MysqlOptions.RejectReadOnly {
+		dsnParams = append(dsnParams, "rejectReadOnly=true")
 	}
 
 	if len(dsnParams) > 0 {

--- a/fddb/config_test.go
+++ b/fddb/config_test.go
@@ -153,15 +153,16 @@ func TestDBConfigConnFullString_MySQL(t *testing.T) {
 		User:   "root",
 		DB:     "test",
 		MysqlOptions: MysqlOptions{
-			Timeout:      10000000,
-			ReadTimeout:  20000000,
-			WriteTimeout: 30000000,
+			Timeout:        10000000,
+			ReadTimeout:    20000000,
+			WriteTimeout:   30000000,
+			RejectReadOnly: true,
 		},
 	}
-	assert.Equal(t, c.ConnString(), "root@tcp(127.0.0.1:3306)/test?timeout=10ms&readTimeout=20ms&writeTimeout=30ms")
+	assert.Equal(t, c.ConnString(), "root@tcp(127.0.0.1:3306)/test?timeout=10ms&readTimeout=20ms&writeTimeout=30ms&rejectReadOnly=true")
 
 	c.Password = "r007"
-	assert.Equal(t, c.ConnString(), "root:r007@tcp(127.0.0.1:3306)/test?timeout=10ms&readTimeout=20ms&writeTimeout=30ms")
+	assert.Equal(t, c.ConnString(), "root:r007@tcp(127.0.0.1:3306)/test?timeout=10ms&readTimeout=20ms&writeTimeout=30ms&rejectReadOnly=true")
 }
 
 func TestDBConfigConnString_Postgres(t *testing.T) {

--- a/fddb/config_test.go
+++ b/fddb/config_test.go
@@ -1,8 +1,9 @@
 package fddb
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDBConfig(t *testing.T) {


### PR DESCRIPTION
Over the weekend of 11th, 12th July an incident where a failover of database by
AWS resulted in errors on archimedes consumer due to a switch of a writer to a
reader. Archimedes consumer and other applications could not automatically
recover as expected during the incident.

This is because the mysql driver held the connection open with the read-only
replica. To ensure that this doesn't occur again, we want to enable the
https://github.com/go-sql-driver/mysql#rejectreadonly option. Add this option to
the MysqlOptions so that users of the library can add it if necessary.

https://jira.deliveryhero.com/browse/CART-3403

Also, small changes following the boy scout rule :D